### PR TITLE
[css] hide scrollbars when not needed

### DIFF
--- a/design/style.css
+++ b/design/style.css
@@ -262,7 +262,7 @@ figure > img {
 }
 
 div.mathjax {
-  overflow-x: scroll;
+  overflow-x: auto;
   background-color: #fdf6e3;
 }
 


### PR DESCRIPTION
Use of `overflow-x: scroll` shows an empty scrollbar on some platforms (like Firefox on Linux). Only display the scrollbar if scrolling is needed by switching to `overflow-x: auto`.